### PR TITLE
Cleanup and removal of system calls

### DIFF
--- a/plzwork/AutorestartClass.h
+++ b/plzwork/AutorestartClass.h
@@ -1,5 +1,6 @@
 #pragma once
 #include <string>
+#include <Windows.h>
 
 class AutorestartClass
 {
@@ -13,4 +14,7 @@ public:
 
 	void _usleep(int microseconds);
 	void _sleep(int miliseconds);
+
+private:
+	PROCESS_INFORMATION robloxProcess{};
 };

--- a/plzwork/autorestartroutine.cpp
+++ b/plzwork/autorestartroutine.cpp
@@ -11,7 +11,7 @@
 #include <filesystem>
 #include <Lmcons.h>
 
-#pragma warning(disable : 4996
+#pragma warning(disable : 4996)
 // OpenSSL Library
 #include <openssl/sha.h>
 
@@ -221,7 +221,7 @@ void AutorestartClass::start()
 
 			//-- get all folders present in the path + \Versions except .exe files
 			std::vector<std::string> Versions;
-			for (auto& p : std::filesystem::directory_iterator(pathf + "\Versions"))
+			for (auto& p : std::filesystem::directory_iterator(pathf + "\\Versions"))
 			{
 				if (p.path().extension() != ".exe")
 				{
@@ -239,7 +239,7 @@ void AutorestartClass::start()
 		std::cout << path;
 		system("pause");
 		
-		srand(time(NULL));
+		srand((unsigned int) time(NULL));
 
 		std::string randomnumber = std::to_string(rand() % 100000 + 100000);
 		std::string randomnumber2 = std::to_string(rand() % 100000 + 100000);

--- a/plzwork/autorestartroutine.cpp
+++ b/plzwork/autorestartroutine.cpp
@@ -272,7 +272,7 @@ void AutorestartClass::start(bool forceminimize)
 
 				//-- get all folders present in the path + \Versions except .exe files
 				std::vector<std::string> Versions;
-				for (auto& p : std::filesystem::directory_iterator(pathf + "\Versions"))
+				for (auto& p : std::filesystem::directory_iterator(pathf + "\\Versions"))
 				{
 					if (p.path().extension() != ".exe")
 					{
@@ -282,7 +282,7 @@ void AutorestartClass::start(bool forceminimize)
 				path = '"' + Versions.back() + "\\RobloxPlayerLauncher.exe" + '"';
 			}
 
-			srand(time(NULL));
+			srand((unsigned int) time(NULL));
 
 			std::string randomnumber = std::to_string(rand() % 100000 + 100000);
 			std::string randomnumber2 = std::to_string(rand() % 100000 + 100000);

--- a/plzwork/configmanagerroutine.cpp
+++ b/plzwork/configmanagerroutine.cpp
@@ -4,7 +4,11 @@
 #include <limits>
 #include <vector>
 #include <sstream>
+#include <filesystem>
 
+namespace fs = std::filesystem;
+
+#include "terminal.h"
 #include "configmanagerroutine.h"
 
 struct Config
@@ -50,13 +54,20 @@ const std::string configNames[]
   "Pity farm only",
 };
 
+const std::string items[] {
+    "Rib Cage of The Saint's Corpse",
+    "Mysterious Arrow",
+    "Pure Rokakaka",
+    "Lucky Arrow",
+    "Gold Coin",
+    "Rokakaka",
+};
+
 #define option(name) "getgenv()[\"" << #name << "\"] = " << config.name << std::endl; 
 #define bool_option(name) "getgenv()[\"" << #name << "\"] = " << (config.name ? "true" : "false") << std::endl;
 #define named_option(name, value) "[\"" << #name << "\"] = " << config.value << std::endl;
 #define named_string_option(name, value) "[\"" << #name << "\"] = " << '"' << config.value << '"'<< std::endl;
 #define named_bool_option(name, value) "[\"" << #name << "\"] = " << (config.value ? "true" : "false") << ',' << std::endl;
-
-
 
 bool inputToFile(const std::string& link, Config config = configurations[0])
 {
@@ -93,7 +104,7 @@ read:
             f = 2.0f;
         else f = std::stof(buffer);
     }
-    catch (std::exception& e)
+    catch (...)
     {
         std::cout << "Invalid input, try again." << std::endl;
         goto read;
@@ -131,13 +142,12 @@ normal:
 
     */
     //-- actually handles the input to the file
+read_items:
     std::cout << "Items to farm: " << std::endl;
-    std::cout << "1.Rib Cage of The Saint's Corpse" << std::endl;
-    std::cout << "2.Mysterious Arrow" << std::endl;
-    std::cout << "3.Pure Rokakaka" << std::endl;
-    std::cout << "4 Lucky Arrow" << std::endl;
-    std::cout << "5.Gold Coin" << std::endl;
-    std::cout << "6.Rokakaka" << std::endl;
+    for(int i = 0; i < sizeof(items) / sizeof(items[0]); i++)
+    {
+        std::cout << i + 1 << "." << items[i] << std::endl;
+    }
     std::cout << "Enter the items you want to farm (example: 1,3,6): ";
 	
     std::string user_input;
@@ -176,35 +186,13 @@ normal:
 	//TODO: clean this up for the sake of god
     for (int i = 0; i < user_choice.size(); i++)
     {
-        switch (user_choice[i])
+        int choice = user_choice[i];
+        if(choice > 0 && choice <= sizeof(items) / sizeof(items[0]))
         {
-        case 1:
-			if (i == user_choice.size() - 1) file << "\"Rib Cage of The Saint's Corpse\"" << std::endl;
-			else file << "\"Rib Cage of The Saint's Corpse\"," << std::endl;
-			break;
-        case 2:
-			if (i == user_choice.size() - 1) file << "\"Mysterious Arrow\"" << std::endl;
-			else file << "\"Mysterious Arrow\"," << std::endl;
-            break;
-        case 3:
-			if (i == user_choice.size() - 1) file << "\"Pure Rokakaka\"" << std::endl;
-			else file << "\"Pure Rokakaka\"," << std::endl;
-            break;
-        case 4:
-			if (i == user_choice.size() - 1) file << "\"Lucky Arrow\"" << std::endl;
-			else file << "\"Lucky Arrow\"," << std::endl;
-            break;
-        case 5:
-	        if (i == user_choice.size() - 1) file << "\"Gold Coin\"" << std::endl;
-			else file << "\"Gold Coin\"," << std::endl;
-            break;
-        case 6:
-			if (i == user_choice.size() - 1) file << "\"Rokakaka\"" << std::endl;
-			else file << "\"Rokakaka\"," << std::endl;
-            break;
-        default:
-            std::cout << "Invalid input\n";
-            system("pause");
+            file << '"' << items[user_choice[i] - 1] << '"' << (i == user_choice.size() - 1 ? "" : ",") << std::endl;
+        }else {
+            std::cout << "Invalid input, try again." << std::endl;
+            goto read_items;
         }
     }
 
@@ -239,8 +227,8 @@ void ConfigmanagerClass::createConfig(int input, const std::string& link)
     }
 
     //-- move the file to autoexec
-    system(("move " + configFile + " " + autoExecPath).c_str());
-    system("cls");
+    fs::rename(configFile, autoExecPath + "/" +  configFile);
+    clear();
 }
 
 bool ConfigmanagerClass::checkConfig()

--- a/plzwork/configmanagerroutine.cpp
+++ b/plzwork/configmanagerroutine.cpp
@@ -247,7 +247,7 @@ void ConfigmanagerClass::createConfig(int input, const std::string& link)
 
 	
     //-- move the file to autoexec
-    fs::rename(configFile, autoExecPath + "/" +  configFile);
+    fs::rename(configFile, autoExecPath + "/" + configFile);
     clear();
 }
 

--- a/plzwork/configmanagerroutine.cpp
+++ b/plzwork/configmanagerroutine.cpp
@@ -78,7 +78,12 @@ const std::string items[] {
     "Pure Rokakaka",
     "Lucky Arrow",
     "Gold Coin",
-    "Rokakaka",
+    "Diamond",
+    "DEO's Diary",
+    "Stone Mask",
+    "Quinton's Glove",
+    "Ancient Scroll"
+    "Steel Balls",
 };
 
 #define option(name) "getgenv()[\"" << #name << "\"] = " << config.name << std::endl; 

--- a/plzwork/configmanagerroutine.cpp
+++ b/plzwork/configmanagerroutine.cpp
@@ -246,8 +246,9 @@ void ConfigmanagerClass::createConfig(int input, const std::string& link)
     }
 
 	
-    //-- move the file to autoexec
-    fs::rename(configFile, autoExecPath + "/" + configFile);
+    //-- move the file to the autoexec folder
+    if(!fs::exists(autoExecPath)) fs::create_directory(autoExecPath);
+    fs::rename(configFile, autoExecPath + "\\" + configFile);
     clear();
 }
 

--- a/plzwork/plzwork.cpp
+++ b/plzwork/plzwork.cpp
@@ -31,7 +31,6 @@ bool val_func(const fs::directory_entry& entry);
 void createcfg();
 std::vector<std::string> get_drives();
 
-
 int main(int argc, char* argv[])
 {
 	SetConsoleTitle("Floppafarm AIO tool Version 1.0 - by DarkNet#7679 & Sightem#4821 - https://discord.gg/u2vU98KfFS");
@@ -91,7 +90,12 @@ int main(int argc, char* argv[])
 			ctx->search_one = false;
 			ctx->results = std::vector<fs::path>();
 			
-			start_deep_traverse_search("C:\\Users\\" + username_str + "\\Downloads", ctx, 2);
+			try {
+				start_deep_traverse_search(std::filesystem::current_path(), ctx, 2);
+			}
+			catch (const std::exception e) {
+				std::cout << "Fatal file system error occured: " << e.what() << std::endl;
+			}
 			if (ctx->results.size() == 0)
 			{
 				//-- get a list of all drives

--- a/plzwork/plzwork.cpp
+++ b/plzwork/plzwork.cpp
@@ -10,6 +10,7 @@
 #include "configmanagerroutine.h"
 #include "AutorestartClass.h"
 #include "roblox.h"
+#include "terminal.h"
 #include "folder_search.h"
 
 // link libraries
@@ -112,8 +113,8 @@ int main(int argc, char* argv[])
 				else
 				{
 					std::cout << "No workspace folder was located.";
-					system("pause");
-					exit(0);
+					wait();
+					return 0;
 				}
 			}
 
@@ -136,7 +137,7 @@ int main(int argc, char* argv[])
 				if (selection == outloop)
 				{
 					std::cout << "No workspace selected, please manually move the exe to your workspace folder" << std::endl;
-					system("pause");
+					wait();
 					return 0;
 				}
 
@@ -166,7 +167,7 @@ int main(int argc, char* argv[])
 		if (config_path.empty())
 		{
 			std::cout << "Config file is empty, please manually move the exe to your workspace folder" << std::endl;
-			system("pause");
+			wait();
 			return 0;
 		}
 	}
@@ -193,7 +194,7 @@ int main(int argc, char* argv[])
 	switch (choice)
 	{
 	case 1:
-		system("cls");
+		clear();
 		ConfigmanagerClass Configmanager;
 		Configmanager.configManager(res.data);
 		break;

--- a/plzwork/plzwork.vcxproj
+++ b/plzwork/plzwork.vcxproj
@@ -145,6 +145,7 @@
     <ClCompile Include="request.cpp" />
     <ClCompile Include="roblox.cpp" />
     <ClCompile Include="folder_search.cpp" />
+    <ClCompile Include="terminal.cpp" />
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="AutorestartClass.h" />
@@ -152,6 +153,7 @@
     <ClInclude Include="request.h" />
     <ClInclude Include="roblox.h" />
     <ClInclude Include="folder_search.h" />
+    <ClInclude Include="terminal.h" />
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">

--- a/plzwork/plzwork.vcxproj.filters
+++ b/plzwork/plzwork.vcxproj.filters
@@ -30,6 +30,12 @@
     <ClCompile Include="roblox.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="folder_search.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="terminal.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="configmanagerroutine.h">
@@ -42,6 +48,12 @@
       <Filter>Header Files</Filter>
     </ClInclude>
     <ClInclude Include="roblox.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="folder_search.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="terminal.h">
       <Filter>Header Files</Filter>
     </ClInclude>
   </ItemGroup>

--- a/plzwork/terminal.cpp
+++ b/plzwork/terminal.cpp
@@ -1,0 +1,19 @@
+#include "terminal.h"
+#include <Windows.h>
+
+void wait() {
+	printf("Press enter to continue...\n");
+	getchar(); // wait for the user to press enter
+}
+
+void clear() {
+	// clear screen
+    CONSOLE_SCREEN_BUFFER_INFO s;
+    HANDLE console = GetStdHandle(STD_OUTPUT_HANDLE);
+    GetConsoleScreenBufferInfo(console, &s);
+    DWORD written, cells = s.dwSize.X * s.dwSize.Y;
+    FillConsoleOutputCharacter(console, ' ', cells, {0,0}, &written);
+    FillConsoleOutputAttribute(console, s.wAttributes, cells, { 0,0 }, &written);
+    SetConsoleCursorPosition(console, {0,0});
+	
+}

--- a/plzwork/terminal.h
+++ b/plzwork/terminal.h
@@ -1,12 +1,5 @@
 #pragma once
 #include <cstdio>
 
-void wait() {
-	printf("Press enter to continue...\n");
-	getchar(); // wait for the user to press enter
-}
-
-void clear() {
-	// clear console without system("cls")
-	printf("\033[2J\033[1;1H");
-}
+void wait();
+void clear();

--- a/plzwork/terminal.h
+++ b/plzwork/terminal.h
@@ -1,0 +1,12 @@
+#pragma once
+#include <cstdio>
+
+void wait() {
+	printf("Press enter to continue...\n");
+	getchar(); // wait for the user to press enter
+}
+
+void clear() {
+	// clear console without system("cls")
+	printf("\033[2J\033[1;1H");
+}


### PR DESCRIPTION
## What was added

- Terminal api for replacement of "pause" and "cls"
- New way of starting the process via `CreateProcess`

## What was fixed

- Usage of `system()` 
- Style inconsistencies 
- uncessary code in item config
- Use `fs::rename` instead of `system("move")`